### PR TITLE
Persist light/dark theme preference - Let users pick light or dark theme and remember it

### DIFF
--- a/client/src/functionalAreas/settings/pages/ProfileSettingsPage.css
+++ b/client/src/functionalAreas/settings/pages/ProfileSettingsPage.css
@@ -1,0 +1,93 @@
+.profile-settings {
+  max-width: 520px;
+}
+
+.profile-settings__header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.profile-settings__header h1 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.profile-settings__header a {
+  font-size: 0.95rem;
+}
+
+.profile-settings__panel {
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 20px;
+  background: var(--color-surface);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.profile-settings__panel h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.profile-settings__options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.profile-settings__option {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.profile-settings__option:has(input:checked) {
+  border-color: var(--color-link);
+  background: var(--color-surface-muted);
+}
+
+.profile-settings__option input {
+  margin-top: 3px;
+}
+
+.profile-settings__option span {
+  display: block;
+  font-weight: 600;
+}
+
+.profile-settings__option small {
+  display: block;
+  color: var(--color-text-muted);
+  font-weight: 400;
+  margin-top: 2px;
+}
+
+.profile-settings__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.profile-settings__muted {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.profile-settings__error {
+  color: #f87171;
+  font-size: 0.95rem;
+}
+
+.profile-settings__success {
+  color: #4ade80;
+  font-size: 0.95rem;
+}

--- a/client/src/functionalAreas/settings/pages/ProfileSettingsPage.tsx
+++ b/client/src/functionalAreas/settings/pages/ProfileSettingsPage.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  getUserSettings,
+  patchUserSettings,
+} from "../../../shared/services/api.service";
+import { ClientRoutes } from "../../../shared/clientRoutes";
+import {
+  isUiTheme,
+  setUiTheme,
+  setUiThemeLive,
+  type UiTheme,
+} from "../../../shared/theme";
+import "./ProfileSettingsPage.css";
+
+export default function ProfileSettingsPage() {
+  const [draft, setDraft] = useState<UiTheme>("light");
+  const committedRef = useRef<UiTheme>("light");
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [savedFlash, setSavedFlash] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    void getUserSettings()
+      .then((s) => {
+        if (!active) return;
+        const t = isUiTheme(s.themePreference) ? s.themePreference : "light";
+        committedRef.current = t;
+        setDraft(t);
+        setUiTheme(t);
+        setLoadError(null);
+      })
+      .catch(() => {
+        if (!active) return;
+        setLoadError("Could not load settings.");
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+      setUiTheme(committedRef.current);
+    };
+  }, []);
+
+  const onDraftChange = (next: UiTheme) => {
+    setDraft(next);
+    setUiThemeLive(next);
+  };
+
+  const onSave = async () => {
+    setSaveError(null);
+    setSaving(true);
+    try {
+      const updated = await patchUserSettings({ themePreference: draft });
+      const t = isUiTheme(updated.themePreference)
+        ? updated.themePreference
+        : "light";
+      committedRef.current = t;
+      setUiTheme(t);
+      setSavedFlash(true);
+      window.setTimeout(() => setSavedFlash(false), 2000);
+    } catch {
+      setSaveError("Could not save. Try again.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="profile-settings">
+      <div className="profile-settings__header">
+        <Link to={ClientRoutes.HOME}>← Home</Link>
+        <h1>Profile settings</h1>
+      </div>
+
+      {loadError ? <p className="profile-settings__error">{loadError}</p> : null}
+
+      <div className="profile-settings__panel">
+        <h2>Appearance</h2>
+        <p className="profile-settings__muted">
+          Choose a light (day) or dark (night) interface. Save to store this on
+          your account.
+        </p>
+
+        <div
+          className="profile-settings__options"
+          aria-busy={loading}
+          aria-disabled={loading}
+        >
+          <label className="profile-settings__option">
+            <input
+              type="radio"
+              name="theme"
+              value="light"
+              checked={draft === "light"}
+              disabled={loading}
+              onChange={() => onDraftChange("light")}
+            />
+            <span>
+              Light
+              <small>Bright background, best in daylight.</small>
+            </span>
+          </label>
+          <label className="profile-settings__option">
+            <input
+              type="radio"
+              name="theme"
+              value="dark"
+              checked={draft === "dark"}
+              disabled={loading}
+              onChange={() => onDraftChange("dark")}
+            />
+            <span>
+              Dark
+              <small>Dimmed colors, easier on the eyes at night.</small>
+            </span>
+          </label>
+        </div>
+
+        <div className="profile-settings__actions">
+          <button type="button" disabled={loading || saving} onClick={onSave}>
+            {saving ? "Saving…" : "Save appearance"}
+          </button>
+          {savedFlash ? (
+            <span className="profile-settings__success">Saved.</span>
+          ) : null}
+          {saveError ? (
+            <span className="profile-settings__error">{saveError}</span>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/shared/App.tsx
+++ b/client/src/shared/App.tsx
@@ -20,6 +20,7 @@ import TripDetailsPage from "../functionalAreas/trips/pages/TripDetailsPage";
 import TagDetailPage from "../functionalAreas/experiences/pages/TagDetailPage";
 import MediaGalleryPage from "../functionalAreas/experiences/pages/MediaGalleryPage";
 import MyTripsPage from "../functionalAreas/trips/pages/MyTripsPage";
+import ProfileSettingsPage from "../functionalAreas/settings/pages/ProfileSettingsPage";
 
 export default function App() {
   const { isAuthenticated } = useAuth();
@@ -82,6 +83,10 @@ export default function App() {
 
         <Route path={ClientRoutes.INTERESTS} element={<InterestsPage />} />
         <Route path={ClientRoutes.TAG_DETAILS} element={<TagDetailPage />} />
+        <Route
+          path={ClientRoutes.PROFILE_SETTINGS}
+          element={<ProfileSettingsPage />}
+        />
         <Route path="*" element={<Navigate to={ClientRoutes.HOME} replace />} />
         </Route>
     </Routes>

--- a/client/src/shared/RootLayout.tsx
+++ b/client/src/shared/RootLayout.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from "react";
 import { NavLink, Outlet } from "react-router-dom";
 import { ClientRoutes } from "./clientRoutes";
 import { useAuth } from "../functionalAreas/auth/hooks/useAuth";
+import { getUserSettings } from "./services/api.service";
+import { isUiTheme, setUiTheme } from "./theme";
 
 export default function RootLayout() {
   const { isAuthenticated, logout } = useAuth();
@@ -20,21 +22,30 @@ export default function RootLayout() {
     return () => document.removeEventListener("mousedown", onDocumentClick);
   }, []);
 
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    let cancelled = false;
+    void getUserSettings()
+      .then((s) => {
+        if (cancelled) return;
+        const t = isUiTheme(s.themePreference) ? s.themePreference : "light";
+        setUiTheme(t);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated]);
+
   return (
     <>
       {isAuthenticated && (
-        <nav
-          className="top-site-nav"
-          style={{ display: "flex", flexWrap: "wrap", gap: 12, padding: 12, borderBottom: "1px solid #e5e7eb", alignItems: "center" }}
-        >
+        <nav className="top-site-nav">
           <NavLink to={ClientRoutes.HOME}>Home</NavLink>
           <NavLink to={ClientRoutes.EXPLORE}>Explore</NavLink>
           <NavLink to={ClientRoutes.INTERESTS}>My Interests</NavLink>
 
-          <div
-            ref={profileMenuRef}
-            style={{ marginLeft: "auto", display: "flex", gap: 12, position: "relative" }}
-          >
+          <div ref={profileMenuRef} className="site-nav-profile">
             <button
               type="button"
               onClick={() => setIsProfileOpen((prev) => !prev)}
@@ -46,23 +57,7 @@ export default function RootLayout() {
             </button>
 
             {isProfileOpen && (
-              <div
-                role="menu"
-                style={{
-                  position: "absolute",
-                  top: "calc(100% + 8px)",
-                  right: 0,
-                  minWidth: 180,
-                  background: "#fff",
-                  border: "1px solid #e5e7eb",
-                  borderRadius: 8,
-                  boxShadow: "0 8px 24px rgba(0,0,0,0.1)",
-                  display: "grid",
-                  gap: 4,
-                  padding: 8,
-                  zIndex: 10,
-                }}
-              >
+              <div className="profile-menu" role="menu">
                 <NavLink
                   to={ClientRoutes.MY_EXPERIENCES}
                   onClick={() => setIsProfileOpen(false)}
@@ -84,15 +79,12 @@ export default function RootLayout() {
                   My Trips
                 </NavLink>
 
-                <a
-                  href="#"
-                  onClick={(event) => {
-                    event.preventDefault();
-                    setIsProfileOpen(false);
-                  }}
+                <NavLink
+                  to={ClientRoutes.PROFILE_SETTINGS}
+                  onClick={() => setIsProfileOpen(false)}
                 >
-                  Profile Settings
-                </a>
+                  Profile settings
+                </NavLink>
 
                 <button
                   type="button"
@@ -100,7 +92,6 @@ export default function RootLayout() {
                     setIsProfileOpen(false);
                     logout();
                   }}
-                  style={{ textAlign: "left" }}
                 >
                   Logout
                 </button>
@@ -110,8 +101,7 @@ export default function RootLayout() {
         </nav>
       )}
 
-      {/* This is the “body replaced by the router” */}
-      <main style={{ padding: 16 }}>
+      <main className="app-main">
         <Outlet />
       </main>
     </>

--- a/client/src/shared/clientRoutes.tsx
+++ b/client/src/shared/clientRoutes.tsx
@@ -16,4 +16,5 @@ export const ClientRoutes = {
   TAG_DETAILS: "/tags/:id",
   REVIEW_CREATE: "/experiences/:id/reviews/create",
   REVIEW_UPDATE: "/experiences/:id/reviews/:reviewId/update",
+  PROFILE_SETTINGS: "/profile/settings",
 };

--- a/client/src/shared/index.css
+++ b/client/src/shared/index.css
@@ -2,38 +2,127 @@
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
+:root[data-theme="light"],
+:root:not([data-theme]) {
+  color-scheme: light;
+  --color-bg: #f8fafc;
+  --color-bg-page: #ffffff;
+  --color-text: #0f172a;
+  --color-text-muted: #64748b;
+  --color-border: #e2e8f0;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f1f5f9;
+  --color-link: #2563eb;
+  --color-link-hover: #1d4ed8;
+  --color-button-bg: #e2e8f0;
+  --color-button-text: #0f172a;
+  --color-card: #e2e8f0;
+  --color-card-border: #94a3b8;
+  --color-photo-border: #cbd5e1;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --color-bg: #0b1220;
+  --color-bg-page: #0f172a;
+  --color-text: #e2e8f0;
+  --color-text-muted: #94a3b8;
+  --color-border: #1e293b;
+  --color-surface: #111827;
+  --color-surface-muted: #1e293b;
+  --color-link: #93c5fd;
+  --color-link-hover: #bfdbfe;
+  --color-button-bg: #1e293b;
+  --color-button-text: #e2e8f0;
+  --color-card: #1e293b;
+  --color-card-border: #334155;
+  --color-photo-border: #475569;
+}
+
+html,
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background-color: var(--color-bg-page);
+  color: var(--color-text);
+}
+
+#root {
+  min-height: 100vh;
+}
+
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--color-link);
   text-decoration: inherit;
 }
+
 a:hover {
-  color: #535bf2;
+  color: var(--color-link-hover);
 }
 
 nav.top-site-nav a {
   font-weight: 400;
 }
 
-body {
-  margin: 0;
-  min-width: 320px;
-  min-height: 100vh;
+nav.top-site-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 12px;
+  align-items: center;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface);
 }
 
-#root {
-  min-height: 100vh;
+nav.top-site-nav .site-nav-profile {
+  margin-left: auto;
+  display: flex;
+  gap: 12px;
+  position: relative;
+}
+
+nav.top-site-nav .profile-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 180px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  display: grid;
+  gap: 4px;
+  padding: 8px;
+  z-index: 10;
+}
+
+nav.top-site-nav .profile-menu a,
+nav.top-site-nav .profile-menu button {
+  color: var(--color-text);
+  background: transparent;
+  border: none;
+  padding: 6px 8px;
+  border-radius: 6px;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+}
+
+nav.top-site-nav .profile-menu a:hover,
+nav.top-site-nav .profile-menu button:hover {
+  background: var(--color-surface-muted);
+}
+
+main.app-main {
+  padding: 16px;
 }
 
 main.auth-page {
@@ -52,9 +141,9 @@ main.auth-page {
   width: 100%;
   max-width: 420px;
   padding: 24px;
-  border: 1px solid rgba(125, 125, 125, 0.2);
+  border: 1px solid var(--color-border);
   border-radius: 12px;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--color-surface);
 }
 
 .auth-page form {
@@ -71,21 +160,21 @@ main.auth-page {
 
 .auth-page input {
   padding: 10px 12px;
-  border: 1px solid rgba(125, 125, 125, 0.35);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   font: inherit;
-  background: transparent;
+  background: var(--color-bg-page);
   color: inherit;
 }
 
 .auth-page input:focus {
-  outline: 2px solid #646cff;
+  outline: 2px solid var(--color-link);
   outline-offset: 2px;
 }
 
 .auth-page .form-error,
 .auth-page .field-error {
-  color: #ff6b6b;
+  color: #f87171;
   font-size: 0.9em;
 }
 
@@ -100,41 +189,25 @@ h1 {
 
 button {
   border-radius: 8px;
-  border: 1px solid transparent;
+  border: 1px solid var(--color-border);
   padding: 0.6em 1.2em;
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--color-button-bg);
+  color: var(--color-button-text);
   cursor: pointer;
   transition: border-color 0.25s;
 }
+
 button:hover {
-  border-color: #646cff;
+  border-color: var(--color-link);
 }
+
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}
-
-
-
-
-/* Photos */
-
 
 .experience-list {
   display: flex;
@@ -143,24 +216,22 @@ button:focus-visible {
   gap: 1rem;
 }
 
-.experience-card {   
+.experience-card {
   margin-bottom: 20px;
   padding: 10px;
-  border: 2px solid #000000;
-  background-color: lightslategray;
-  border-radius: 12px;   /* 👈 rounds the corners */
-
-  display: flex;         
-  flex-direction: column;  
+  border: 2px solid var(--color-card-border);
+  background-color: var(--color-card);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
   align-items: center;
 }
 
-
 .photo {
-  width: 300px;      
-  height: 300;    
+  width: 300px;
+  height: 300;
   object-fit: cover;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-photo-border);
 }
 
 .experience-card-header {

--- a/client/src/shared/main.tsx
+++ b/client/src/shared/main.tsx
@@ -5,6 +5,9 @@ import App from "./App.tsx";
 import { AuthProvider } from "../functionalAreas/auth/context/AuthContext.tsx";
 
 import "leaflet/dist/leaflet.css";
+import { hydrateThemeFromCache } from "./theme";
+
+hydrateThemeFromCache();
 
 if (import.meta.env.DEV) {
   console.log("Dev");

--- a/client/src/shared/services/api.service.ts
+++ b/client/src/shared/services/api.service.ts
@@ -40,6 +40,30 @@ export const authSignup = async (input: {
   return response.data;
 };
 
+export type UserSettingsDto = {
+  preferredFeedSort: string;
+  themePreference: "light" | "dark";
+  lastUpdated: string;
+};
+
+export type UserSettingsPatch = {
+  preferredFeedSort?: "newest" | "highestRated" | "recommended";
+  themePreference?: "light" | "dark";
+};
+
+export const getUserSettings = async () => {
+  const response = await apiClient.get<UserSettingsDto>("/users/me/settings");
+  return response.data;
+};
+
+export const patchUserSettings = async (body: UserSettingsPatch) => {
+  const response = await apiClient.patch<UserSettingsDto>(
+    "/users/me/settings",
+    body
+  );
+  return response.data;
+};
+
 export type Interest = {
   id: number;
   name: string;

--- a/client/src/shared/theme.ts
+++ b/client/src/shared/theme.ts
@@ -1,0 +1,39 @@
+export const THEME_STORAGE_KEY = "cstp.ui.theme";
+
+export type UiTheme = "light" | "dark";
+
+export function isUiTheme(value: string): value is UiTheme {
+  return value === "light" || value === "dark";
+}
+
+/** Update `<html data-theme>` only (no localStorage). */
+export function setUiThemeLive(theme: UiTheme): void {
+  document.documentElement.dataset.theme = theme;
+}
+
+/** Apply theme to `<html>` and cache for login screen before settings load. */
+export function setUiTheme(theme: UiTheme): void {
+  setUiThemeLive(theme);
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
+/** Read last saved theme from cache (no network). */
+export function readCachedUiTheme(): UiTheme | null {
+  try {
+    const raw = localStorage.getItem(THEME_STORAGE_KEY);
+    return raw && isUiTheme(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Run once at startup: paint cached theme or default light. */
+export function hydrateThemeFromCache(): void {
+  if (typeof document === "undefined") return;
+  const cached = readCachedUiTheme();
+  setUiTheme(cached ?? "light");
+}

--- a/server/prisma/migrations/20260514130000_add_theme_preference/migration.sql
+++ b/server/prisma/migrations/20260514130000_add_theme_preference/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "UserSettings" ADD COLUMN "themePreference" TEXT NOT NULL DEFAULT 'light';

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -25,11 +25,13 @@ model User {
 }
 
 model UserSettings {
-  id                Int      @id @default(autoincrement())
-  userId            Int      @unique
-  preferredFeedSort String   @default("newest")
-  lastUpdated       DateTime @updatedAt
-  user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id                  Int      @id @default(autoincrement())
+  userId              Int      @unique
+  preferredFeedSort   String   @default("newest")
+  /// UI appearance: light (day) or dark (night).
+  themePreference     String   @default("light")
+  lastUpdated         DateTime @updatedAt
+  user                User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
 }

--- a/server/src/controllers/settingsController.ts
+++ b/server/src/controllers/settingsController.ts
@@ -33,6 +33,7 @@ export async function patchSettings(
     const body = SettingsPatchBodySchema.parse(req.body);
     const settings = await settingsService.updateSettingsForUser(req.user.id, {
       preferredFeedSort: body.preferredFeedSort,
+      themePreference: body.themePreference,
     });
     return res.status(200).json(settings);
   } catch (err) {

--- a/server/src/models/settings.ts
+++ b/server/src/models/settings.ts
@@ -2,8 +2,11 @@ import * as z from "zod";
 
 export const PREFERRED_FEED_SORT_VALUES = ["newest", "highestRated", "recommended"] as const;
 
+export const THEME_PREFERENCE_VALUES = ["light", "dark"] as const;
+
 export const SettingsPatchBodySchema = z.object({
   preferredFeedSort: z.enum(PREFERRED_FEED_SORT_VALUES).optional(),
+  themePreference: z.enum(THEME_PREFERENCE_VALUES).optional(),
 });
 
 export type SettingsPatchBody = z.infer<typeof SettingsPatchBodySchema>;

--- a/server/src/services/settingsService.ts
+++ b/server/src/services/settingsService.ts
@@ -10,35 +10,42 @@ export async function getSettingsForUser(userId: number) {
       data: {
         userId,
         preferredFeedSort: "newest",
+        themePreference: "light",
       },
     });
   }
 
   return {
     preferredFeedSort: settings.preferredFeedSort,
+    themePreference: settings.themePreference,
     lastUpdated: settings.lastUpdated,
   };
 }
 
 export async function updateSettingsForUser(
   userId: number,
-  data: { preferredFeedSort?: string }
+  data: { preferredFeedSort?: string; themePreference?: string }
 ) {
   const updated = await prisma.userSettings.upsert({
     where: { userId },
     create: {
       userId,
       preferredFeedSort: data.preferredFeedSort ?? "newest",
+      themePreference: data.themePreference ?? "light",
     },
     update: {
       ...(data.preferredFeedSort != null && {
         preferredFeedSort: data.preferredFeedSort,
+      }),
+      ...(data.themePreference != null && {
+        themePreference: data.themePreference,
       }),
     },
   });
 
   return {
     preferredFeedSort: updated.preferredFeedSort,
+    themePreference: updated.themePreference,
     lastUpdated: updated.lastUpdated,
   };
 }


### PR DESCRIPTION
This PR adds support for appearance themes: after you sign in, you can go to Profile settings and choose light or dark. Your choice is saved with your account, so the app comes back the same way next time instead of resetting.

- Add UserSettings.themePreference (Prisma + migration).
- Extend GET/PATCH /api/users/me/settings with themePreference.
- Client: cache + data-theme hydration, CSS variables, profile settings page.