### PR TITLE
custom tag creation

### DIFF
--- a/client/src/functionalAreas/experiences/components/ExperienceForm.css
+++ b/client/src/functionalAreas/experiences/components/ExperienceForm.css
@@ -149,12 +149,27 @@
 .exp-form-chip {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.5rem;
   border: 1px solid var(--surface-border);
   border-radius: 999px;
-  padding: 0.25rem 0.5rem;
+  padding: 0.3rem 0.35rem 0.3rem 0.6rem;
   background: var(--chip-bg);
   font-size: 0.82rem;
+}
+
+.exp-form-chip-action {
+  border: 1px solid var(--surface-border);
+  border-radius: 999px;
+  width: 1.2rem;
+  height: 1.2rem;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  background: rgba(255, 255, 255, 0.18);
+  color: inherit;
+  cursor: pointer;
 }
 
 .exp-form-actions {

--- a/client/src/functionalAreas/experiences/components/TagSelection.tsx
+++ b/client/src/functionalAreas/experiences/components/TagSelection.tsx
@@ -1,4 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
+import { createCategoryTag } from "../../../shared/services/api.service";
+import SearchSelect, {
+  type SearchSelectOption,
+} from "../../../shared/components/SearchSelect";
 import type { CategoryOption, TagOption } from "../types/types";
 
 interface TagSelectionProps {
@@ -12,6 +16,47 @@ interface TagSelectionProps {
   onCategoryChange?: (categoryId: number | null) => void | Promise<void>;
   onTagIdsChange: (tagIds: number[]) => void;
   likedTags?: TagOption[];
+}
+
+const NON_ALPHANUMERIC = /[^a-z0-9]+/g;
+const WHITESPACE = /\s+/g;
+
+function normalizeTagText(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(NON_ALPHANUMERIC, " ")
+    .trim()
+    .replace(WHITESPACE, " ");
+}
+
+function searchScore(tag: TagOption, query: string): number {
+  if (!query) return 0;
+
+  const labelNormalized = normalizeTagText(tag.label);
+  const slugNormalized = normalizeTagText(tag.slug);
+  const haystack = `${labelNormalized} ${slugNormalized}`.trim();
+  const queryTokens = query.split(" ").filter(Boolean);
+  const hayTokens = haystack.split(" ").filter(Boolean);
+
+  if (labelNormalized === query || slugNormalized === query) return 220;
+  if (labelNormalized.startsWith(query) || slugNormalized.startsWith(query)) return 180;
+  if (labelNormalized.includes(query) || slugNormalized.includes(query)) return 140;
+
+  if (queryTokens.length && queryTokens.every((token) => hayTokens.includes(token))) {
+    return 120;
+  }
+
+  if (
+    queryTokens.length &&
+    queryTokens.every((token) =>
+      hayTokens.some((hayToken) => hayToken.startsWith(token))
+    )
+  ) {
+    return 100;
+  }
+
+  if (haystack.includes(query)) return 90;
+  return -1;
 }
 
 export default function TagSelection({
@@ -29,98 +74,164 @@ export default function TagSelection({
   const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(
     initialCategoryId
   );
-  const [featureSearch, setFeatureSearch] = useState("");
-  const [featureToAddId, setFeatureToAddId] = useState<number | null>(null);
-  const [selectedFeatureIds, setSelectedFeatureIds] = useState<number[]>(
-    initialTagIds
-  );
+  const [tagSearch, setTagSearch] = useState("");
+  const [selectedTagIds, setSelectedTagIds] = useState<number[]>(initialTagIds);
+  const [categoryTags, setCategoryTags] = useState<TagOption[]>(availableFeatures);
+  const [createTagError, setCreateTagError] = useState<string | null>(null);
+  const [creatingTag, setCreatingTag] = useState(false);
 
   useEffect(() => {
-    onTagIdsChange([...selectedFeatureIds]);
-  }, [onTagIdsChange, selectedFeatureIds]);
+    setCategoryTags(availableFeatures);
+  }, [availableFeatures]);
+
+  useEffect(() => {
+    onTagIdsChange([...selectedTagIds]);
+  }, [onTagIdsChange, selectedTagIds]);
 
   useEffect(() => {
     void onCategoryChange?.(selectedCategoryId);
   }, [onCategoryChange, selectedCategoryId]);
 
   useEffect(() => {
-    if (
-      selectedCategoryId === null ||
-      featuresLoading ||
-      availableFeatures.length === 0
-    ) {
+    if (selectedCategoryId === null || featuresLoading || categoryTags.length === 0) {
       return;
     }
-    const allowedFeatureIds = new Set(availableFeatures.map((feature) => feature.id));
-    setSelectedFeatureIds((current) =>
-      current.filter((featureId) => allowedFeatureIds.has(featureId))
-    );
-  }, [availableFeatures, featuresLoading, selectedCategoryId]);
-
-  const selectableFeatures = useMemo(
-    () =>
-      availableFeatures.filter((feature) => {
-        if (selectedFeatureIds.includes(feature.id)) return false;
-        if (!featureSearch.trim()) return true;
-
-        const normalizedSearch = featureSearch.toLowerCase();
-        return (
-          feature.label.toLowerCase().includes(normalizedSearch) ||
-          feature.slug.toLowerCase().includes(normalizedSearch)
-        );
-      }),
-    [availableFeatures, featureSearch, selectedFeatureIds]
-  );
+    const allowedTagIds = new Set(categoryTags.map((tag) => tag.id));
+    setSelectedTagIds((current) => current.filter((tagId) => allowedTagIds.has(tagId)));
+  }, [categoryTags, featuresLoading, selectedCategoryId]);
 
   function handleCategorySelect(value: string) {
+    setCreateTagError(null);
     if (!value) {
       setSelectedCategoryId(null);
-      setSelectedFeatureIds([]);
-      setFeatureSearch("");
-      setFeatureToAddId(null);
+      setSelectedTagIds([]);
+      setTagSearch("");
       return;
     }
 
     const nextCategoryId = Number(value);
     setSelectedCategoryId(nextCategoryId);
-    setSelectedFeatureIds([]);
-    setFeatureSearch("");
-    setFeatureToAddId(null);
+    setSelectedTagIds([]);
+    setTagSearch("");
+    setCategoryTags([]);
   }
 
-  function handleAddFeature() {
-    if (featureToAddId === null) return;
-    if (selectedFeatureIds.includes(featureToAddId)) return;
-    setSelectedFeatureIds([...selectedFeatureIds, featureToAddId]);
-    setFeatureToAddId(null);
+  function handleRemoveTag(tagId: number) {
+    setSelectedTagIds((current) => current.filter((id) => id !== tagId));
   }
 
-  function handleRemoveFeature(featureId: number) {
-    setSelectedFeatureIds(selectedFeatureIds.filter((id) => id !== featureId));
+  function selectTagId(tagId: number) {
+    setSelectedTagIds((current) =>
+      current.includes(tagId) ? current : [...current, tagId]
+    );
+    setTagSearch("");
+    setCreateTagError(null);
   }
 
-  const selectedFeatures = selectedFeatureIds.map((id) => {
-    const feature = availableFeatures.find((item) => item.id === id);
-    if (feature) return feature;
-    return { id, label: `Feature #${id}`, slug: "loading", categoryId: -1 };
+  const selectedTags = selectedTagIds.map((id) => {
+    const tag = categoryTags.find((item) => item.id === id);
+    if (tag) return tag;
+    return { id, label: `Tag #${id}`, slug: "loading", categoryId: -1 };
   });
 
   const hasCategory = selectedCategoryId !== null;
-
-  const savedTagsForCategory = useMemo(() => {
-    if (selectedCategoryId === null) return [];
-    return likedTags.filter(
-      (t) =>
-        t.categoryId === selectedCategoryId && !selectedFeatureIds.includes(t.id)
+  const likedTagIds = useMemo(() => {
+    if (selectedCategoryId === null) return new Set<number>();
+    return new Set(
+      likedTags
+        .filter((tag) => tag.categoryId === selectedCategoryId)
+        .map((tag) => tag.id)
     );
-  }, [likedTags, selectedCategoryId, selectedFeatureIds]);
+  }, [likedTags, selectedCategoryId]);
+
+  const normalizedQuery = normalizeTagText(tagSearch);
+  const rankedOptions = useMemo(() => {
+    const unselectedTags = categoryTags.filter(
+      (tag) => !selectedTagIds.includes(tag.id)
+    );
+
+    const scored = unselectedTags
+      .map((tag) => ({
+        tag,
+        liked: likedTagIds.has(tag.id),
+        score: searchScore(tag, normalizedQuery),
+      }))
+      .filter((row) => (normalizedQuery ? row.score >= 0 : true));
+
+    scored.sort((a, b) => {
+      if (normalizedQuery && a.score !== b.score) return b.score - a.score;
+      if (a.liked !== b.liked) return a.liked ? -1 : 1;
+      return a.tag.label.localeCompare(b.tag.label);
+    });
+
+    return scored;
+  }, [categoryTags, likedTagIds, normalizedQuery, selectedTagIds]);
+
+  const exactNormalizedDuplicateExists = useMemo(() => {
+    if (!normalizedQuery) return false;
+    return categoryTags.some(
+      (tag) =>
+        normalizeTagText(tag.label) === normalizedQuery ||
+        normalizeTagText(tag.slug) === normalizedQuery
+    );
+  }, [categoryTags, normalizedQuery]);
+
+  const searchOptions: SearchSelectOption[] = rankedOptions.map((row) => ({
+    id: String(row.tag.id),
+    label: row.tag.label,
+    supportingText: row.tag.slug,
+    badgeText: row.liked ? "Saved" : undefined,
+  }));
+
+  const shouldShowAddRow =
+    hasCategory &&
+    normalizedQuery.length > 0 &&
+    !exactNormalizedDuplicateExists &&
+    !featuresLoading &&
+    !creatingTag;
+
+  const addRow = shouldShowAddRow
+    ? { label: `Add new tag: "${tagSearch.trim()}"` }
+    : null;
+
+  async function handleCreateTag() {
+    if (selectedCategoryId === null) return;
+    const name = tagSearch.trim();
+    if (!name) return;
+
+    setCreateTagError(null);
+    setCreatingTag(true);
+    try {
+      const tag = await createCategoryTag(selectedCategoryId, name);
+      setCategoryTags((current) => {
+        const exists = current.some((item) => item.id === tag.id);
+        if (exists) return current;
+        return [...current, tag].sort((a, b) => a.label.localeCompare(b.label));
+      });
+      selectTagId(tag.id);
+    } catch (err) {
+      const message =
+        err &&
+        typeof err === "object" &&
+        "response" in err &&
+        typeof (err as { response?: { data?: { error?: unknown } } }).response?.data
+          ?.error === "string"
+          ? (err as { response?: { data?: { error?: string } } }).response?.data?.error
+          : undefined;
+      setCreateTagError(message ?? "Could not create tag.");
+    } finally {
+      setCreatingTag(false);
+    }
+  }
 
   return (
     <section className="exp-form-section">
       <h3 className="exp-form-section-title">Tags</h3>
 
       {tagsLoading && <p className="exp-form-helper">Loading tags...</p>}
-      {tagsError && <p className="exp-form-error">{tagsError}</p>}
+      {(tagsError || createTagError) && (
+        <p className="exp-form-error">{tagsError ?? createTagError}</p>
+      )}
 
       <label className="exp-form-field">
         <span>Category</span>
@@ -132,102 +243,51 @@ export default function TagSelection({
           <option value="">Select a category</option>
           {availableCategories.map((category) => (
             <option key={category.id} value={category.id}>
-              {category.label} ({category.slug})
+              {category.label}
             </option>
           ))}
         </select>
       </label>
 
       {!hasCategory ? (
-        <p className="exp-form-helper">
-          Choose a category to enable feature selection.
-        </p>
+        <p className="exp-form-helper">Choose a category to search and select tags.</p>
       ) : (
         <div className="exp-form-subsection">
-          {likedTags.length > 0 && (
-            <p className="exp-form-helper">
-              {savedTagsForCategory.length > 0
-                ? "Quick-add from your saved tags (this category):"
-                : "Pick a category to see saved tags you can add in one click."}
-            </p>
-          )}
-          {savedTagsForCategory.length > 0 && (
-            <div className="exp-form-chip-list" style={{ marginBottom: "12px" }}>
-              {savedTagsForCategory.map((t) => (
-                <button
-                  key={t.id}
-                  type="button"
-                  className="exp-form-chip"
-                  onClick={() => {
-                    if (selectedFeatureIds.includes(t.id)) return;
-                    setSelectedFeatureIds([...selectedFeatureIds, t.id]);
-                  }}
-                >
-                  + {t.label}
-                </button>
-              ))}
-            </div>
-          )}
-
-          {featuresLoading && <p className="exp-form-helper">Loading features...</p>}
-
-          <label className="exp-form-field">
-            <span>Search features</span>
-            <input
-              type="text"
-              value={featureSearch}
-              onChange={(e) => setFeatureSearch(e.target.value)}
-              placeholder="Search feature by label or slug"
-              disabled={featuresLoading || !!tagsError}
-            />
-          </label>
-
-          <div className="exp-form-inline-group">
-            <label className="exp-form-field">
-              <span>Features</span>
-              <select
-                value={featureToAddId === null ? "" : String(featureToAddId)}
-                onChange={(e) =>
-                  setFeatureToAddId(e.target.value ? Number(e.target.value) : null)
-                }
-                disabled={
-                  featuresLoading || !!tagsError || selectableFeatures.length === 0
-                }
-              >
-                <option value="">Select a feature</option>
-                {selectableFeatures.map((feature) => (
-                  <option key={feature.id} value={feature.id}>
-                    {feature.label} ({feature.slug})
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <button
-              type="button"
-              onClick={handleAddFeature}
-              disabled={featureToAddId === null || featuresLoading}
-            >
-              Add feature
-            </button>
-          </div>
+          <SearchSelect
+            label="Search tags"
+            placeholder="Search tags by name or slug"
+            value={tagSearch}
+            disabled={featuresLoading || !!tagsError}
+            loading={featuresLoading}
+            options={searchOptions}
+            addRow={addRow}
+            noResultsText="No tags match your search."
+            keepOpenOnSelect
+            onValueChange={setTagSearch}
+            onSelectOption={(optionId) => selectTagId(Number(optionId))}
+            onSelectAddRow={() => {
+              void handleCreateTag();
+            }}
+          />
         </div>
       )}
 
-      {selectedFeatures.length > 0 && (
+      {selectedTags.length > 0 && (
         <div className="exp-form-subsection">
-          <p className="exp-form-helper">Selected features</p>
+          <p className="exp-form-helper">Selected tags</p>
           <div className="exp-form-chip-list">
-            {selectedFeatures.map((feature) => (
-              <div key={feature.id} className="exp-form-chip">
+            {selectedTags.map((tag) => (
+              <div key={tag.id} className="exp-form-chip">
                 <span>
-                  {feature.label} ({feature.slug})
+                  {tag.label}
                 </span>
                 <button
                   type="button"
-                  onClick={() => handleRemoveFeature(feature.id)}
+                  className="exp-form-chip-action"
+                  aria-label={`Remove ${tag.label}`}
+                  onClick={() => handleRemoveTag(tag.id)}
                 >
-                  Remove
+                  −
                 </button>
               </div>
             ))}

--- a/client/src/functionalAreas/experiences/hooks/useCategoryFeatures.ts
+++ b/client/src/functionalAreas/experiences/hooks/useCategoryFeatures.ts
@@ -10,6 +10,7 @@ export default function useCategoryFeatures(categoryId: number | null) {
   useEffect(() => {
     if (!categoryId) {
       setFeatures([]);
+      setError(null);
       return;
     }
 
@@ -18,12 +19,13 @@ export default function useCategoryFeatures(categoryId: number | null) {
     async function load() {
       try {
         setLoading(true);
+        setError(null);
         const res = await apiClient.get<TagOption[]>(
           `/categories/${categoryId}/tags`
         );
         if (!cancelled) setFeatures(res.data);
       } catch {
-        if (!cancelled) setError("Unable to load features.");
+        if (!cancelled) setError("Unable to load tags.");
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/client/src/shared/components/SearchSelect.css
+++ b/client/src/shared/components/SearchSelect.css
@@ -1,0 +1,153 @@
+.search-select {
+  position: relative;
+}
+
+.search-select.is-open {
+  /* Reserve room so the absolute dropdown has breathing space near form bottom. */
+  padding-bottom: 290px;
+}
+
+.search-select-dropdown {
+  position: absolute;
+  z-index: 30;
+  width: 100%;
+  margin-top: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 10px;
+  background: rgba(14, 18, 28, 0.96);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.28);
+  overflow: visible;
+  padding: 10px;
+}
+
+.search-select-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.search-select-list li {
+  display: inline-flex;
+}
+
+.search-select-chip {
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  text-align: left;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px 6px 10px;
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+
+.search-select-chip:hover {
+  background: rgba(106, 143, 232, 0.15);
+  border-color: rgba(106, 143, 232, 0.6);
+}
+
+.search-select-chip.is-highlighted {
+  background: rgba(106, 143, 232, 0.28);
+  border-color: rgba(106, 143, 232, 0.75);
+}
+
+.search-select-chip-add {
+  border-style: dashed;
+}
+
+.search-select-chip-text-block {
+  display: grid;
+  gap: 1px;
+}
+
+.search-select-chip-text {
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.search-select-main {
+  font-size: 0.88rem;
+  line-height: 1.05rem;
+}
+
+.search-select-supporting {
+  font-size: 0.72rem;
+  opacity: 0.75;
+}
+
+.search-select-badge {
+  justify-self: start;
+  margin-top: 2px;
+  font-size: 0.7rem;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 999px;
+  padding: 1px 6px 0;
+  opacity: 0.9;
+}
+
+.search-select-chip-action {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 0.84rem;
+  font-weight: 700;
+  flex: 0 0 auto;
+}
+
+.search-select-empty {
+  margin: 0;
+  padding: 8px;
+  font-size: 0.85rem;
+  opacity: 0.76;
+}
+
+@media (prefers-color-scheme: light) {
+  .search-select-dropdown {
+    border-color: rgba(22, 30, 47, 0.16);
+    background: #ffffff;
+    box-shadow: 0 10px 22px rgba(15, 23, 42, 0.16);
+  }
+
+  .search-select-chip {
+    border-color: rgba(22, 30, 47, 0.18);
+    background: #f7f9ff;
+  }
+
+  .search-select-chip:hover {
+    border-color: rgba(53, 89, 187, 0.55);
+    background: #edf2ff;
+  }
+
+  .search-select-chip.is-highlighted {
+    background: rgba(53, 89, 187, 0.12);
+    border-color: rgba(53, 89, 187, 0.55);
+  }
+
+  .search-select-badge {
+    border-color: rgba(22, 30, 47, 0.22);
+  }
+
+  .search-select-chip-action {
+    border-color: rgba(22, 30, 47, 0.25);
+    background: #ffffff;
+  }
+}
+
+@media (max-width: 760px) {
+  .search-select.is-open {
+    padding-bottom: 250px;
+  }
+}

--- a/client/src/shared/components/SearchSelect.tsx
+++ b/client/src/shared/components/SearchSelect.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import "./SearchSelect.css";
+
+export type SearchSelectOption = {
+  id: string;
+  label: string;
+  supportingText?: string;
+  badgeText?: string;
+};
+
+type AddRow = {
+  label: string;
+};
+
+type SearchSelectProps = {
+  label: string;
+  placeholder: string;
+  value: string;
+  disabled?: boolean;
+  loading?: boolean;
+  options: SearchSelectOption[];
+  addRow?: AddRow | null;
+  noResultsText?: string;
+  onValueChange: (nextValue: string) => void;
+  onSelectOption: (optionId: string) => void;
+  onSelectAddRow?: () => void;
+  keepOpenOnSelect?: boolean;
+};
+
+type Row =
+  | { type: "option"; key: string; option: SearchSelectOption }
+  | { type: "add"; key: string; add: AddRow };
+
+export default function SearchSelect({
+  label,
+  placeholder,
+  value,
+  disabled = false,
+  loading = false,
+  options,
+  addRow = null,
+  noResultsText = "No tags found.",
+  onValueChange,
+  onSelectOption,
+  onSelectAddRow,
+  keepOpenOnSelect = false,
+}: SearchSelectProps) {
+  const listboxId = useId();
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+
+  const rows = useMemo<Row[]>(() => {
+    const baseRows = options.map<Row>((option) => ({
+      type: "option",
+      key: option.id,
+      option,
+    }));
+    if (!addRow) return baseRows;
+    return [...baseRows, { type: "add", key: "__add__", add: addRow }];
+  }, [addRow, options]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onPointerDown = (event: MouseEvent) => {
+      if (!rootRef.current) return;
+      if (!rootRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    return () => document.removeEventListener("mousedown", onPointerDown);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || rows.length === 0) {
+      setHighlightedIndex(-1);
+      return;
+    }
+    setHighlightedIndex(0);
+  }, [isOpen, rows]);
+
+  function selectRow(row: Row) {
+    if (row.type === "option") {
+      onSelectOption(row.option.id);
+    } else {
+      onSelectAddRow?.();
+    }
+    if (!keepOpenOnSelect) {
+      setIsOpen(false);
+      setHighlightedIndex(-1);
+    }
+  }
+
+  function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (!isOpen && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
+      setIsOpen(true);
+      event.preventDefault();
+      return;
+    }
+
+    if (event.key === "Escape") {
+      setIsOpen(false);
+      setHighlightedIndex(-1);
+      return;
+    }
+
+    if (!isOpen || rows.length === 0) return;
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setHighlightedIndex((prev) => (prev + 1) % rows.length);
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setHighlightedIndex((prev) => (prev <= 0 ? rows.length - 1 : prev - 1));
+      return;
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault();
+      const row = rows[highlightedIndex];
+      if (row) selectRow(row);
+    }
+  }
+
+  const activeId =
+    highlightedIndex >= 0 && highlightedIndex < rows.length
+      ? `${listboxId}-option-${highlightedIndex}`
+      : undefined;
+
+  return (
+    <div
+      ref={rootRef}
+      className={`search-select${isOpen && !disabled ? " is-open" : ""}`}
+    >
+      <label className="exp-form-field">
+        <span>{label}</span>
+        <input
+          role="combobox"
+          aria-expanded={isOpen}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-activedescendant={activeId}
+          value={value}
+          placeholder={placeholder}
+          disabled={disabled}
+          onFocus={() => setIsOpen(true)}
+          onChange={(event) => {
+            onValueChange(event.target.value);
+            if (!isOpen) setIsOpen(true);
+          }}
+          onKeyDown={onKeyDown}
+        />
+      </label>
+
+      {isOpen && !disabled && (
+        <div className="search-select-dropdown">
+          {loading ? (
+            <p className="search-select-empty">Loading tags...</p>
+          ) : rows.length === 0 ? (
+            <p className="search-select-empty">{noResultsText}</p>
+          ) : (
+            <ul id={listboxId} role="listbox" className="search-select-list">
+              {rows.map((row, index) => {
+                const highlighted = index === highlightedIndex;
+                const id = `${listboxId}-option-${index}`;
+                if (row.type === "add") {
+                  return (
+                    <li id={id} key={row.key} role="option" aria-selected={highlighted}>
+                      <button
+                        type="button"
+                        className={`search-select-chip search-select-chip-add ${
+                          highlighted ? "is-highlighted" : ""
+                        }`}
+                        onMouseDown={(event) => event.preventDefault()}
+                        onClick={() => selectRow(row)}
+                      >
+                        <span className="search-select-chip-text">{row.add.label}</span>
+                        <span className="search-select-chip-action" aria-hidden="true">
+                          +
+                        </span>
+                      </button>
+                    </li>
+                  );
+                }
+
+                return (
+                  <li id={id} key={row.key} role="option" aria-selected={highlighted}>
+                    <button
+                      type="button"
+                      className={`search-select-chip ${highlighted ? "is-highlighted" : ""}`}
+                      onMouseDown={(event) => event.preventDefault()}
+                      onClick={() => selectRow(row)}
+                    >
+                      <span className="search-select-chip-text-block">
+                        <span className="search-select-main">{row.option.label}</span>
+                        {row.option.supportingText ? (
+                          <span className="search-select-supporting">
+                            {row.option.supportingText}
+                          </span>
+                        ) : null}
+                        {row.option.badgeText ? (
+                          <span className="search-select-badge">{row.option.badgeText}</span>
+                        ) : null}
+                      </span>
+                      <span className="search-select-chip-action" aria-hidden="true">
+                        +
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/shared/services/api.service.ts
+++ b/client/src/shared/services/api.service.ts
@@ -172,3 +172,17 @@ export const likeTag = async (tagId: number) => {
 export const unlikeTag = async (tagId: number) => {
   await apiClient.delete(`/users/me/liked-tags/${tagId}`);
 };
+
+export type TagSummary = {
+  id: number;
+  slug: string;
+  label: string;
+  categoryId: number;
+};
+
+export const createCategoryTag = async (categoryId: number, name: string) => {
+  const response = await apiClient.post<TagSummary>(`/categories/${categoryId}/tags`, {
+    name,
+  });
+  return response.data;
+};

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,18 +11,16 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1030.0",
         "@prisma/client": "^6.19.3",
-        "@prisma/client": "^6.19.0",
         "@types/morgan": "^1.9.10",
         "argon2": "^0.44.0",
         "cors": "^2.8.5",
         "cross-env": "^10.1.0",
-        "dotenv": "^17.2.3",
+        "dotenv": "^17.4.2",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.1",
         "multer": "^2.1.1",
         "tsx": "^4.20.6",
-        "zod": "^4.3.6",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -9289,7 +9287,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "scripts": {
     "lint": "eslint",
-    "start:dev": "cross-env NODE_ENV=development tsx --watch src/index.ts",
-    "start:production": "cross-env NODE_ENV=production tsx src/index.ts",
+    "start:dev": "cross-env NODE_ENV=development node --import tsx src/index.ts",
+    "start:production": "cross-env NODE_ENV=production node --import tsx src/index.ts",
     "prisma:dev": "prisma dev -n crowd-sourced-travel-planner",
     "prisma:generate": "prisma generate --no-engine",
     "prisma:migrate:deploy": "node scripts/run-prisma-migrate-deploy.mjs",

--- a/server/prisma/migrations/20260515000100_add_tag_normalized_label_unique/migration.sql
+++ b/server/prisma/migrations/20260515000100_add_tag_normalized_label_unique/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "Tag" ADD COLUMN "normalizedLabel" TEXT;
+
+UPDATE "Tag"
+SET "normalizedLabel" = trim(regexp_replace(lower("label"), '[^a-z0-9]+', ' ', 'g'));
+
+ALTER TABLE "Tag" ALTER COLUMN "normalizedLabel" SET NOT NULL;
+
+CREATE UNIQUE INDEX "Tag_categoryId_normalizedLabel_key" ON "Tag"("categoryId", "normalizedLabel");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -144,10 +144,13 @@ model Tag {
   id             Int             @id @default(autoincrement())
   slug           String          @unique
   label          String
+  normalizedLabel String
   categoryId     Int
   experienceTags ExperienceTag[]
   likedByUsers     UserLikedTag[]
   category       Category        @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+
+  @@unique([categoryId, normalizedLabel])
 }
 
 model ExperienceTag {

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from "../src/generated/prisma/client";
+import { normalizeTagText } from "../src/lib/tagText";
 const prisma = new PrismaClient();
 
 /**
@@ -88,11 +89,13 @@ async function main() {
         where: { slug: t.slug },
         update: {
           label: t.label,
+          normalizedLabel: normalizeTagText(t.label),
           categoryId: category.id,
         },
         create: {
           slug: t.slug,
           label: t.label,
+          normalizedLabel: normalizeTagText(t.label),
           categoryId: category.id,
         },
       });

--- a/server/src/__tests__/controllers/experienceControllerTagFilter.tests.ts
+++ b/server/src/__tests__/controllers/experienceControllerTagFilter.tests.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextFunction, Request, Response } from "express";
+
+const { listExperiencesMock } = vi.hoisted(() => ({
+  listExperiencesMock: vi.fn(),
+}));
+
+vi.mock("../../services/experienceService", () => ({
+  createExperience: vi.fn(),
+  getExperience: vi.fn(),
+  listExperiences: listExperiencesMock,
+  updateExperience: vi.fn(),
+  editExperience: vi.fn(),
+  deleteExperience: vi.fn(),
+}));
+
+import { listExperiences } from "../../controllers/experienceController";
+
+describe("experienceController tag slug filtering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes slug-based tag filters to service", async () => {
+    listExperiencesMock.mockResolvedValue([]);
+
+    const req = {
+      query: {
+        minLat: "44.7",
+        maxLat: "45.1",
+        minLng: "-123.0",
+        maxLng: "-122.5",
+        tags: "lake-lagoon,beach",
+        tagMode: "or",
+      },
+    } as unknown as Request;
+    const status = vi.fn().mockReturnThis();
+    const json = vi.fn().mockReturnThis();
+    const res = { status, json } as unknown as Response;
+    const next = vi.fn() as unknown as NextFunction;
+
+    await listExperiences(req, res, next);
+
+    expect(listExperiencesMock).toHaveBeenCalledTimes(1);
+    const args = listExperiencesMock.mock.calls[0][0];
+    expect(args.where).toMatchObject({
+      experienceTags: {
+        some: {
+          tag: {
+            slug: { in: ["lake-lagoon", "beach"] },
+          },
+        },
+      },
+    });
+    expect(status).toHaveBeenCalledWith(200);
+  });
+});

--- a/server/src/__tests__/lib/tagText.tests.ts
+++ b/server/src/__tests__/lib/tagText.tests.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTagText, sanitizeTagLabel, slugFromTagText } from "../../lib/tagText";
+
+describe("tag text helpers", () => {
+  it("normalizes separators/punctuation/spacing consistently", () => {
+    expect(normalizeTagText("Lake / Lagoon")).toBe("lake lagoon");
+    expect(normalizeTagText("lake-lagoon")).toBe("lake lagoon");
+    expect(normalizeTagText(" lake   lagoon ")).toBe("lake lagoon");
+    expect(normalizeTagText("lake___lagoon!!")).toBe("lake lagoon");
+  });
+
+  it("sanitizes labels without removing user-facing punctuation", () => {
+    expect(sanitizeTagLabel("  Lake   / Lagoon  ")).toBe("Lake / Lagoon");
+  });
+
+  it("slugifies using normalized tokens", () => {
+    expect(slugFromTagText("Lake / Lagoon")).toBe("lake-lagoon");
+  });
+});

--- a/server/src/__tests__/middleware/authMiddleware.tests.ts
+++ b/server/src/__tests__/middleware/authMiddleware.tests.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import type { NextFunction, Response } from "express";
+import { requireAuth, type AuthenticatedRequest } from "../../middleware/authMiddleware";
+
+describe("authMiddleware.requireAuth", () => {
+  it("returns 401 when authorization header is missing", async () => {
+    const req = {
+      headers: {},
+    } as unknown as AuthenticatedRequest;
+    const status = vi.fn().mockReturnThis();
+    const json = vi.fn().mockReturnThis();
+    const res = { status, json } as unknown as Response;
+    const next = vi.fn() as unknown as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith({ error: "Missing Authorization header" });
+  });
+});

--- a/server/src/__tests__/middleware/authMiddleware.tests.ts
+++ b/server/src/__tests__/middleware/authMiddleware.tests.ts
@@ -1,5 +1,23 @@
 import { describe, expect, it, vi } from "vitest";
 import type { NextFunction, Response } from "express";
+
+const { findUniqueMock, verifyMock } = vi.hoisted(() => ({
+  findUniqueMock: vi.fn(),
+  verifyMock: vi.fn(),
+}));
+
+vi.mock("../../db/prisma", () => ({
+  default: {
+    user: {
+      findUnique: findUniqueMock,
+    },
+  },
+}));
+
+vi.mock("../../services/authTokenService", () => ({
+  verify: verifyMock,
+}));
+
 import { requireAuth, type AuthenticatedRequest } from "../../middleware/authMiddleware";
 
 describe("authMiddleware.requireAuth", () => {
@@ -16,5 +34,28 @@ describe("authMiddleware.requireAuth", () => {
 
     expect(status).toHaveBeenCalledWith(401);
     expect(json).toHaveBeenCalledWith({ error: "Missing Authorization header" });
+  });
+
+  it("sets req.user and calls next when token and user are valid", async () => {
+    verifyMock.mockReturnValue({ id: "42" });
+    findUniqueMock.mockResolvedValue({ id: 42 });
+
+    const req = {
+      headers: { authorization: "Bearer token123" },
+    } as unknown as AuthenticatedRequest;
+    const status = vi.fn().mockReturnThis();
+    const json = vi.fn().mockReturnThis();
+    const res = { status, json } as unknown as Response;
+    const next = vi.fn() as unknown as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(verifyMock).toHaveBeenCalledWith("token123");
+    expect(findUniqueMock).toHaveBeenCalledWith({
+      where: { id: 42 },
+      select: { id: true },
+    });
+    expect(req.user).toEqual({ id: 42 });
+    expect(next).toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/services/experienceService.tests.ts
+++ b/server/src/__tests__/services/experienceService.tests.ts
@@ -149,3 +149,56 @@ describe("experienceService.getExperience reviewCount", () => {
     expect(result?.reviewCount).toBe(2);
   });
 });
+
+describe("experienceService category/tag validation", () => {
+  beforeEach(() => {
+    mockReset(prismaMock);
+    vi.clearAllMocks();
+  });
+
+  it("rejects tagIds that do not belong to selected categoryId", async () => {
+    const tx = {
+      user: {
+        findUnique: vi.fn().mockResolvedValue({ id: 9 }),
+      },
+      category: {
+        findUnique: vi.fn().mockResolvedValue({ id: 5 }),
+      },
+      tag: {
+        findMany: vi.fn().mockResolvedValue([
+          { id: 33, categoryId: 7 },
+        ]),
+      },
+      experience: {
+        create: vi.fn(),
+        findUniqueOrThrow: vi.fn(),
+      },
+      experienceTag: {
+        createMany: vi.fn(),
+      },
+    };
+
+    (prismaMock.$transaction as unknown as ReturnType<typeof vi.fn>)
+      .mockImplementation(async (callback: (client: typeof tx) => unknown) => callback(tx));
+
+    await expect(
+      createExperience({
+        userId: 9,
+        postBody: {
+          title: "Coastal Walk",
+          description:
+            "A memorable walk along the coast with dramatic cliffs and viewpoints.",
+          categoryId: 5,
+          country: "US",
+          latitude: 44.5,
+          longitude: -123.2,
+          tagIds: [33],
+        },
+        files: [],
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: "All tagIds must belong to the selected categoryId.",
+    });
+  });
+});

--- a/server/src/__tests__/services/tagService.tests.ts
+++ b/server/src/__tests__/services/tagService.tests.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "../../generated/prisma/client";
+
+vi.mock("../../db/prisma", () => ({
+  default: mockDeep<PrismaClient>(),
+}));
+
+import prisma from "../../db/prisma";
+import { createTagForCategory, listByCategoryId } from "../../services/tagService";
+
+const prismaMock = prisma as unknown as DeepMockProxy<PrismaClient>;
+
+describe("tagService.listByCategoryId", () => {
+  beforeEach(() => {
+    mockReset(prismaMock);
+  });
+
+  it("requests category tags with stable ordering", async () => {
+    (prismaMock.tag.findMany as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 1, slug: "beach", label: "Beach", categoryId: 3 },
+    ]);
+
+    await listByCategoryId(3);
+
+    expect(prismaMock.tag.findMany).toHaveBeenCalledWith({
+      select: { id: true, slug: true, label: true, categoryId: true },
+      where: { categoryId: 3 },
+      orderBy: [{ label: "asc" }, { id: "asc" }],
+    });
+  });
+});
+
+describe("tagService.createTagForCategory", () => {
+  beforeEach(() => {
+    mockReset(prismaMock);
+  });
+
+  it("creates a new tag for a valid category", async () => {
+    (prismaMock.category.findUnique as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 2,
+    });
+    (prismaMock.tag.findUnique as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (prismaMock.tag.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 9,
+      slug: "anodize",
+      label: "Anodize",
+      categoryId: 2,
+    });
+
+    const result = await createTagForCategory(2, "  Anodize  ");
+
+    expect(result.created).toBe(true);
+    expect(result.tag).toMatchObject({
+      id: 9,
+      slug: "anodize",
+      label: "Anodize",
+      categoryId: 2,
+    });
+  });
+
+  it("rejects empty/whitespace-only names", async () => {
+    await expect(createTagForCategory(2, "   ")).rejects.toMatchObject({
+      status: 400,
+      message: "Tag name is required.",
+    });
+  });
+
+  it("rejects invalid categories", async () => {
+    (prismaMock.category.findUnique as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      null
+    );
+
+    await expect(createTagForCategory(999, "Kayak")).rejects.toMatchObject({
+      status: 400,
+      message: "Invalid categoryId.",
+    });
+  });
+
+  it("returns existing tag when duplicate differs only by case/spacing/punctuation", async () => {
+    const existing = { id: 4, slug: "lake-lagoon", label: "Lake / Lagoon", categoryId: 2 };
+
+    (prismaMock.category.findUnique as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 2,
+    });
+    (prismaMock.tag.findUnique as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      existing
+    );
+
+    const result = await createTagForCategory(2, " LAKE___LAGOON ");
+
+    expect(result.created).toBe(false);
+    expect(result.tag).toEqual(existing);
+    expect(prismaMock.tag.create).not.toHaveBeenCalled();
+  });
+
+  it("allows same normalized name in a different category by generating a unique slug", async () => {
+    (prismaMock.category.findUnique as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 3,
+    });
+
+    (prismaMock.tag.findUnique as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (args: unknown) => {
+        const parsed = args as
+          | { where?: { categoryId_normalizedLabel?: { categoryId: number; normalizedLabel: string } } }
+          | { where?: { slug?: string } };
+        if ("categoryId_normalizedLabel" in (parsed.where ?? {})) {
+          return null;
+        }
+        if (parsed.where && "slug" in parsed.where) {
+          if (parsed.where.slug === "lake-lagoon") return { id: 77 };
+          if (parsed.where.slug === "lake-lagoon-2") return null;
+        }
+        return null;
+      }
+    );
+
+    (prismaMock.tag.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 18,
+      slug: "lake-lagoon-2",
+      label: "Lake Lagoon",
+      categoryId: 3,
+    });
+
+    const result = await createTagForCategory(3, "Lake Lagoon");
+
+    expect(result.created).toBe(true);
+    expect(result.tag.slug).toBe("lake-lagoon-2");
+  });
+});

--- a/server/src/controllers/categoryController.ts
+++ b/server/src/controllers/categoryController.ts
@@ -1,6 +1,8 @@
 import { Request, Response, NextFunction} from "express";
 import * as categoryService from "../services/categoryService";
 import * as tagService from "../services/tagService";
+import { CreateTagBodySchema } from "../models/tag";
+import { AuthenticatedRequest } from "../middleware/authMiddleware";
 
 
 
@@ -25,6 +27,9 @@ async function listTagsForCategory(
 ) {
   try {
     const categoryId = Number(req.params.categoryId);
+    if (!Number.isInteger(categoryId) || categoryId <= 0) {
+      return res.status(400).json({ error: "Invalid category ID" });
+    }
     
     const tags = await tagService.listByCategoryId(categoryId);
     return res.status(200).json(tags);
@@ -33,7 +38,27 @@ async function listTagsForCategory(
   }
 }
 
+async function createTagForCategory(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+) {
+  try {
+    const categoryId = Number(req.params.categoryId);
+    if (!Number.isInteger(categoryId) || categoryId <= 0) {
+      return res.status(400).json({ error: "Invalid category ID" });
+    }
+
+    const body = CreateTagBodySchema.parse(req.body);
+    const result = await tagService.createTagForCategory(categoryId, body.name);
+    return res.status(result.created ? 201 : 200).json(result.tag);
+  } catch (error) {
+    return next(error);
+  }
+}
+
 export {
   listCategories,
-  listTagsForCategory
+  listTagsForCategory,
+  createTagForCategory,
 }

--- a/server/src/lib/tagText.ts
+++ b/server/src/lib/tagText.ts
@@ -1,0 +1,20 @@
+const NON_ALPHANUMERIC = /[^a-z0-9]+/g;
+const WHITESPACE = /\s+/g;
+
+export function normalizeTagText(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(NON_ALPHANUMERIC, " ")
+    .trim()
+    .replace(WHITESPACE, " ");
+}
+
+export function sanitizeTagLabel(input: string): string {
+  return input.trim().replace(WHITESPACE, " ");
+}
+
+export function slugFromTagText(input: string): string {
+  const normalized = normalizeTagText(input);
+  if (!normalized) return "";
+  return normalized.replace(WHITESPACE, "-");
+}

--- a/server/src/models/tag.ts
+++ b/server/src/models/tag.ts
@@ -16,3 +16,13 @@ export const TagListQuerySchema = z.object({
 });
 
 export type TagListQuery = z.infer<typeof TagListQuerySchema>;
+
+export const CreateTagBodySchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "Tag name is required.")
+    .max(64, "Tag name must be 64 characters or fewer."),
+});
+
+export type CreateTagBody = z.infer<typeof CreateTagBodySchema>;

--- a/server/src/routers/category.ts
+++ b/server/src/routers/category.ts
@@ -1,10 +1,12 @@
 import { default as express } from "express";
 import * as categoryController from "../controllers/categoryController";
+import { requireAuth } from "../middleware/authMiddleware";
 
 const router = express.Router();
 
 router.get("/", categoryController.listCategories);
 router.get("/:categoryId/tags", categoryController.listTagsForCategory);
+router.post("/:categoryId/tags", requireAuth, categoryController.createTagForCategory);
 
 
 export default router;

--- a/server/src/services/tagService.ts
+++ b/server/src/services/tagService.ts
@@ -1,7 +1,39 @@
 import prisma from "../db/prisma";
+import {
+  normalizeTagText,
+  sanitizeTagLabel,
+  slugFromTagText,
+} from "../lib/tagText";
+
+const TAG_LIST_SELECT = {
+  id: true,
+  slug: true,
+  label: true,
+  categoryId: true,
+} as const;
+
+function badRequest(message: string) {
+  return { status: 400, message };
+}
+
+async function generateUniqueSlug(baseSlug: string): Promise<string> {
+  let candidate = baseSlug;
+  let suffix = 2;
+
+  while (true) {
+    const existing = await prisma.tag.findUnique({
+      where: { slug: candidate },
+      select: { id: true },
+    });
+    if (!existing) return candidate;
+    candidate = `${baseSlug}-${suffix}`;
+    suffix += 1;
+  }
+}
 
 export async function listTags() {
   return prisma.tag.findMany({
+    select: TAG_LIST_SELECT,
     orderBy: {
       label: "asc"
     }
@@ -26,8 +58,90 @@ export async function getTagById(tagId: number) {
 
 export async function listByCategoryId(categoryId: number) {
   return prisma.tag.findMany({
+    select: TAG_LIST_SELECT,
     where: {
       categoryId: categoryId,
     },
+    orderBy: [{ label: "asc" }, { id: "asc" }],
   });
+}
+
+export async function createTagForCategory(categoryId: number, name: string) {
+  const cleanLabel = sanitizeTagLabel(name);
+  const normalizedLabel = normalizeTagText(cleanLabel);
+
+  if (!normalizedLabel) {
+    throw badRequest("Tag name is required.");
+  }
+
+  const category = await prisma.category.findUnique({
+    where: { id: categoryId },
+    select: { id: true },
+  });
+
+  if (!category) {
+    throw badRequest("Invalid categoryId.");
+  }
+
+  const existing = await prisma.tag.findUnique({
+    where: {
+      categoryId_normalizedLabel: {
+        categoryId,
+        normalizedLabel,
+      },
+    },
+    select: TAG_LIST_SELECT,
+  });
+
+  if (existing) {
+    return { created: false as const, tag: existing };
+  }
+
+  const baseSlug = slugFromTagText(cleanLabel);
+  if (!baseSlug) {
+    throw badRequest("Tag name must include letters or numbers.");
+  }
+
+  let slug = await generateUniqueSlug(baseSlug);
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      const created = await prisma.tag.create({
+        data: {
+          label: cleanLabel,
+          normalizedLabel,
+          slug,
+          categoryId,
+        },
+        select: TAG_LIST_SELECT,
+      });
+
+      return { created: true as const, tag: created };
+    } catch (err) {
+      const isKnown =
+        typeof err === "object" &&
+        err !== null &&
+        "code" in err &&
+        (err as { code?: string }).code === "P2002";
+      if (!isKnown) throw err;
+
+      const duplicate = await prisma.tag.findUnique({
+        where: {
+          categoryId_normalizedLabel: {
+            categoryId,
+            normalizedLabel,
+          },
+        },
+        select: TAG_LIST_SELECT,
+      });
+
+      if (duplicate) {
+        return { created: false as const, tag: duplicate };
+      }
+
+      slug = await generateUniqueSlug(baseSlug);
+    }
+  }
+
+  throw { status: 409, message: "Unable to create a unique tag right now." };
 }


### PR DESCRIPTION
## Summary
This PR updates the experience form tag picker UX and adds backend support for in-app tag creation with category-scoped duplicate protection.

## What Changed

### Frontend
- Replaced the old tag picker flow (separate search + dropdown + add button) with a single reusable search-select/combobox.
- Tag picker now:
  - searches existing tags by label/slug (flexible matching),
  - allows creating a new tag from the dropdown,
  - hides “Add new tag” when input is empty,
  - keeps the dropdown open after selecting a tag (closes on outside click).
- Folded liked-tag quick-add behavior into dropdown suggestions (prioritized/marked as saved).
- Updated visual styling:
  - dropdown suggestions rendered as chip/bubble-style items (left-to-right, wrapping),
  - `+` action for add in suggestions,
  - selected tags keep chips with `−` remove action.
- Added open-state spacing so dropdown has room and does not feel clipped near form bottom.

### Backend
- Added protected endpoint for tag creation:
  - `POST /api/categories/:categoryId/tags` (authenticated users).
- Added tag normalization utilities for duplicate prevention.
- Added category-scoped duplicate enforcement:
  - new `Tag.normalizedLabel`,
  - DB uniqueness on `(categoryId, normalizedLabel)`.
- Added migration to backfill `normalizedLabel` for existing rows.
- Preserved existing slug-based filtering semantics used by Explore/Tag pages.
- Preserved existing experience category/tag validation safeguards.

## Duplicate/Normalization Strategy
- Normalization is case-insensitive and whitespace/separator tolerant.
- Treats punctuation, hyphens, underscores, and slashes consistently.
- Prevents duplicates within the same category (backend authoritative).
- On duplicate create attempts, backend returns the existing tag payload (safe/idempotent behavior for frontend).

## Key Files
- `client/src/shared/components/SearchSelect.tsx`
- `client/src/shared/components/SearchSelect.css`
- `client/src/functionalAreas/experiences/components/TagSelection.tsx`
- `client/src/functionalAreas/experiences/components/ExperienceForm.css`
- `client/src/shared/services/api.service.ts`
- `server/src/lib/tagText.ts`
- `server/src/services/tagService.ts`
- `server/src/controllers/categoryController.ts`
- `server/src/routers/category.ts`
- `server/src/models/tag.ts`
- `server/prisma/schema.prisma`
- `server/prisma/migrations/20260515000100_add_tag_normalized_label_unique/migration.sql`
- `server/prisma/seed.ts`